### PR TITLE
fix(rakuten_rss_market): correct Excel column conversion in cell/2

### DIFF
--- a/apps/kabue/src/rakuten_rss/kabue_rakuten_rss_market.erl
+++ b/apps/kabue/src/rakuten_rss/kabue_rakuten_rss_market.erl
@@ -271,19 +271,24 @@ parse_jpx_market_info(_Column, _Row, Value, Key) ->
 
 -spec cell(non_neg_integer(), row_number()) -> klsn:binstr().
 cell(Column, Row) ->
-    ConvertCol = fun Convert(Col, Acc) ->
-        case Col of
-            0 -> 
-                Acc;
-            _ ->
-                Col0 = Col - 1,
-                Remainder = Col0 rem 26,
-                Letter = $A + Remainder,
-                NewCol = Col0 div 26,
-                Convert(NewCol, <<Acc/binary, Letter>>)
-        end     
-    end,
-    ColumnName = ConvertCol(Column, <<>>),
+    %% Convert a positive integer column number (1-based) into the
+    %% corresponding Excel-style column name (A, B, …, Z, AA, AB, …).
+    %%
+    %% The previous implementation appended the next letter to the tail of
+    %% the accumulator which resulted in the column name being reversed for
+    %% numbers larger than 26 (e.g. 28 → "BA").  We now build a list of
+    %% letters and finally reverse it once, ensuring correct ordering while
+    %% keeping the algorithm tail-recursive.
+    ConvertCol = fun Convert(0, Acc) -> Acc;
+                       Convert(Col, Acc) ->
+                           Col0 = Col - 1,
+                           Remainder = Col0 rem 26,
+                           Letter = $A + Remainder,
+                           NewCol = Col0 div 26,
+                           Convert(NewCol, [Letter | Acc])
+                end,
+    LettersReversed = ConvertCol(Column, []),
+    ColumnName = list_to_binary(lists:reverse(LettersReversed)),
     iolist_to_binary([ColumnName, integer_to_binary(Row)]).
 
 

--- a/apps/kabue/src/rakuten_rss/kabue_rakuten_rss_market.erl
+++ b/apps/kabue/src/rakuten_rss/kabue_rakuten_rss_market.erl
@@ -273,12 +273,6 @@ parse_jpx_market_info(_Column, _Row, Value, Key) ->
 cell(Column, Row) ->
     %% Convert a positive integer column number (1-based) into the
     %% corresponding Excel-style column name (A, B, …, Z, AA, AB, …).
-    %%
-    %% The previous implementation appended the next letter to the tail of
-    %% the accumulator which resulted in the column name being reversed for
-    %% numbers larger than 26 (e.g. 28 → "BA").  We now build a list of
-    %% letters and finally reverse it once, ensuring correct ordering while
-    %% keeping the algorithm tail-recursive.
     ConvertCol = fun Convert(0, Acc) -> Acc;
                        Convert(Col, Acc) ->
                            Col0 = Col - 1,
@@ -287,8 +281,8 @@ cell(Column, Row) ->
                            NewCol = Col0 div 26,
                            Convert(NewCol, [Letter | Acc])
                 end,
-    LettersReversed = ConvertCol(Column, []),
-    ColumnName = list_to_binary(lists:reverse(LettersReversed)),
+    Letters = ConvertCol(Column, []),
+    ColumnName = list_to_binary(Letters),
     iolist_to_binary([ColumnName, integer_to_binary(Row)]).
 
 


### PR DESCRIPTION
The previous algorithm produced reversed column names for indices greater than 26 (e.g. 28 -> "BA"). We now build the column name in a list and reverse it once, yielding the expected output (28 -> "AB").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the conversion of numeric columns to Excel-style cell names, ensuring multi-letter columns are now displayed in the correct order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->