### PR TITLE
perf(handlers): cache application env values in cowboy handlers

### DIFF
--- a/apps/kabue/src/cowboy_handlers/kabue_version_handler.erl
+++ b/apps/kabue/src/cowboy_handlers/kabue_version_handler.erl
@@ -9,7 +9,9 @@
     ]).
 
 init(Req, State) ->
-    {cowboy_rest, Req, State}.
+    {ok, Version} = application:get_env(kabue, version),
+    State1 = maps:put(version, Version, State),
+    {cowboy_rest, Req, State1}.
 
 allowed_methods(Req, State) ->
     { [<<"GET">>], Req, State }.
@@ -17,7 +19,10 @@ allowed_methods(Req, State) ->
 content_types_provided(Req, State) ->
     {[{<<"text/plain">>, to_text}], Req, State}.
 
+to_text(Req, State=#{version := Version}) ->
+    {Version, Req, State};
 to_text(Req, State) ->
+    %% Fallback (should not happen)
     {ok, Version} = application:get_env(kabue, version),
     {Version, Req, State}.
 

--- a/apps/kabue/src/cowboy_handlers/kabue_webhook_handler.erl
+++ b/apps/kabue/src/cowboy_handlers/kabue_webhook_handler.erl
@@ -10,22 +10,21 @@
     ]).
 
 init(Req, State) ->
-    {cowboy_rest, Req, State}.
+    %% Cache webhook configuration.
+    Conf = case application:get_env(kabue, webhook) of
+        {ok, Val} -> Val;
+        _ -> []
+    end,
+    State1 = maps:put(webhook_conf, Conf, State),
+    {cowboy_rest, Req, State1}.
 
 allowed_methods(Req, State) ->
     { [<<"POST">>], Req, State }.
 
-resource_exists(Req=#{bindings:=#{id:=Id}}, State) ->
-    Exists = case application:get_env(kabue, webhook) of
-        {ok, PList} ->
-            case proplists:lookup(Id, PList) of
-                none ->
-                    false;
-                _ ->
-                    true
-            end;
-        _ ->
-            false
+resource_exists(Req=#{bindings:=#{id:=Id}}, State=#{webhook_conf := Conf}) ->
+    Exists = case proplists:lookup(Id, Conf) of
+        none -> false;
+        _ -> true
     end,
     {Exists, Req, State};
 resource_exists(Req, State) ->
@@ -36,8 +35,7 @@ content_types_accepted(Req, State) ->
     {[{'*', webhook}], Req, State}.
 
 
-webhook(Req, State) ->
-    {ok, Conf} = application:get_env(kabue, webhook),
+webhook(Req, State=#{webhook_conf := Conf}) ->
     {_, {Mod, Fun, 1}} = proplists:lookup(klsn_map:get([bindings, id], Req), Conf),
     {ok, ReqBody, Req1} = cowboy_req:read_body(Req),
     Req2 = cowboy_req:set_resp_body(Mod:Fun(ReqBody), Req1),


### PR DESCRIPTION
* kabue_version_handler now reads version during init and stores in state.
* kabue_webhook_handler caches webhook configuration in init, avoiding env lookup on each function call.