### PR TITLE
feat(rest): implement board/2 endpoint client

### DIFF
--- a/apps/kabue/src/mufje/kabue_mufje_rest_apic.erl
+++ b/apps/kabue/src/mufje/kabue_mufje_rest_apic.erl
@@ -9,6 +9,7 @@
       , symbol/0
       , order_id/0
       , ticker/0
+  , board/0
     ]).
 
 -export([
@@ -19,6 +20,7 @@
       , register/2
       , unregister/2
       , unregister_all/1
+  , board/2
     ]).
 
 
@@ -62,6 +64,8 @@
         symbol => symbol()
       , exchange => kabue_mufje_enum:exchange()
     }.
+
+-type board() :: kabue_mufje_types:board().
 
 
 -spec ranking(
@@ -266,6 +270,27 @@ parse_regist_list(Payload) ->
                     }
             end, RegistList),
             {right, Res};
+        {left, Left} ->
+            {left, Left}
+    end.
+
+
+%% ------------------------------------------------------------------
+%%  Board information
+%% ------------------------------------------------------------------
+
+-spec board(ticker(), options()) -> either(board()).
+board(#{symbol := SymbolBin, exchange := ExchangeAtom}, Options) ->
+    ExchangeCode = maps:get(ExchangeAtom, kabue_mufje_enum:exchange()),
+    Uri = iolist_to_binary([
+        "/kabusapi/board/",
+        SymbolBin,
+        "@",
+        klsn_binstr:from_any(ExchangeCode)
+    ]),
+    case request(#{uri => Uri, method => get}, Options) of
+        {right, Payload} ->
+            {right, kabue_mufje_types:payload_to_board(Payload)};
         {left, Left} ->
             {left, Left}
     end.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to retrieve board information using a ticker symbol and exchange code. The response provides detailed board data or an error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->