### PR TITLE
feat(mufje): add order_list REST endpoint (GET /orders) with typed spec

### DIFF
--- a/apps/kabue/src/mufje/kabue_mufje_rest_apic.erl
+++ b/apps/kabue/src/mufje/kabue_mufje_rest_apic.erl
@@ -19,6 +19,7 @@
       , register/2
       , unregister/2
       , unregister_all/1
+      , order_list/2
     ]).
 
 
@@ -467,5 +468,22 @@ request_(Request=#{method:=Method, uri:=Uri}, Options) ->
     end.
 
 % lists:map(fun(#{<<"Symbol">>:=Ticker})-> kabue_rakuten_rss_market:add(Ticker) end, maps:get(<<"Ranking">>, element(2, kabue_mufje_rest_apic:ranking(trading_volume_top, #{})))).
+
+
+%% ------------------------------------------------------------------
+%%  Order list endpoint
+%% ------------------------------------------------------------------
+
+-spec order_list(
+        #{ product => kabue_mufje_enum:product() }
+      , options()) -> either(payload()).
+order_list(Query0, Options) when is_map(Query0) ->
+    Q = maps:from_list(lists:filtermap(fun
+        ({product, Product}) ->
+            {true, {<<"product">>, maps:get(Product, kabue_mufje_enum:product())}};
+        (_) -> false
+    end, maps:to_list(Query0))),
+    request(#{uri => <<"/kabusapi/orders">>, method => get, q => Q}, Options).
+
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve a list of orders filtered by product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->