### PR TITLE
Add rpc route handler

### DIFF
--- a/apps/kabue/src/cowboy_handlers/kabue_rpc_handler.erl
+++ b/apps/kabue/src/cowboy_handlers/kabue_rpc_handler.erl
@@ -8,6 +8,7 @@
       , resource_exists/2
       , content_types_accepted/2
       , rpc/2
+      , allow_missing_post/2
     ]).
 
 %%----------------------------------------------------------------------
@@ -36,6 +37,17 @@ resource_exists(Req, State) ->
 %% We still expect the payload to be JSON and will attempt to decode it.
 content_types_accepted(Req, State) ->
     {[{'*', rpc}], Req, State}.
+
+%%----------------------------------------------------------------------
+%% POST to a *missing* RPC should not be allowed.
+%% The default (no callback) for allow_missing_post/2 is 'true', which would
+%% make Cowboy continue processing the request even when resource_exists/2
+%% returned false, eventually calling rpc/2 and crashing. We override it to
+%% 'false' so Cowboy responds 404 immediately.
+%%----------------------------------------------------------------------
+
+allow_missing_post(Req, State) ->
+    {false, Req, State}.
 
 
 %%----------------------------------------------------------------------

--- a/apps/kabue/src/cowboy_handlers/kabue_rpc_handler.erl
+++ b/apps/kabue/src/cowboy_handlers/kabue_rpc_handler.erl
@@ -1,0 +1,70 @@
+-module(kabue_rpc_handler).
+
+-behaviour(cowboy_rest).
+
+-export([
+        init/2
+      , allowed_methods/2
+      , resource_exists/2
+      , content_types_accepted/2
+      , rpc/2
+    ]).
+
+%%----------------------------------------------------------------------
+%% cowboy_rest callbacks
+%%----------------------------------------------------------------------
+
+init(Req, State) ->
+    {cowboy_rest, Req, State}.
+
+allowed_methods(Req, State) ->
+    { [<<"POST">>], Req, State }.
+
+%% Verify the rpc function exists. If not, return 404.
+resource_exists(Req=#{bindings := #{id := IdBin}}, State) ->
+    Exists = case try_binary_to_existing_atom(IdBin) of
+        {ok, IdAtom} ->
+            erlang:function_exported(kabue_rpc, IdAtom, 1);
+        error ->
+            false
+    end,
+    {Exists, Req, State};
+resource_exists(Req, State) ->
+    {false, Req, State}.
+
+%% Accept any incoming content-type so clients are not forced to set one.
+%% We still expect the payload to be JSON and will attempt to decode it.
+content_types_accepted(Req, State) ->
+    {[{'*', rpc}], Req, State}.
+
+
+%%----------------------------------------------------------------------
+%% Internal helpers
+%%----------------------------------------------------------------------
+
+try_binary_to_existing_atom(Bin) when is_binary(Bin) ->
+    try {ok, binary_to_existing_atom(Bin, utf8)}
+    catch
+        error:badarg -> error
+    end.
+
+%%----------------------------------------------------------------------
+%% Main logic
+%%----------------------------------------------------------------------
+
+rpc(Req=#{bindings := #{id := IdBin}}, State) ->
+    IdAtomResult = try_binary_to_existing_atom(IdBin),
+    case IdAtomResult of
+        {ok, IdAtom} ->
+            {ok, Body, Req1} = cowboy_req:read_body(Req),
+            RequestMap = jsone:decode(Body),
+            Response = apply(kabue_rpc, IdAtom, [RequestMap]),
+            RespJson = jsone:encode(Response),
+            Req2 = cowboy_req:set_resp_header(<<"content-type">>, <<"application/json">>, Req1),
+            Req3 = cowboy_req:set_resp_body(RespJson, Req2),
+            {true, Req3, State};
+        error ->
+            %% Should not happen because resource_exists should have returned false,
+            %% but keep a guard in place.
+            {false, Req, State}
+    end.

--- a/apps/kabue/src/kabue_app.erl
+++ b/apps/kabue/src/kabue_app.erl
@@ -26,6 +26,8 @@ start(_StartType, _StartArgs) ->
             {true, {"/kabue/static/[...]", cowboy_static, {priv_dir, kabue, "static"}}}
       ; (hello_world) ->
             {true, {"/kabue/hello-world", kabue_hello_world_handler, #{}}}
+      ; (rpc) ->
+            {true, {"/kabue/rpc/:id", kabue_rpc_handler, #{}}}
       ; (_) ->
             false
     end,

--- a/apps/kabue/src/kabue_rpc.erl
+++ b/apps/kabue/src/kabue_rpc.erl
@@ -1,0 +1,10 @@
+-module(kabue_rpc).
+
+-export([
+        echo/1
+    ]).
+
+echo(Payload) ->
+    Payload.
+
+

--- a/config/default.config
+++ b/config/default.config
@@ -11,6 +11,7 @@
       , market
       , static
       , hello_world
+      , rpc
     ]}
   , {webhook, [
         {<<"rakuten-rss-market">>, {kabue_rakuten_rss_market, webhook, 1}}

--- a/config/prod.config
+++ b/config/prod.config
@@ -11,6 +11,7 @@
       , market
       , static
       , hello_world
+      , rpc
     ]}
   , {webhook, [
         {<<"rakuten-rss-market">>, {kabue_rakuten_rss_market, webhook, 1}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `/kabue/rpc/:id` HTTP endpoint for handling JSON-RPC requests.
  * Added support for dynamic RPC function dispatch with robust error handling for invalid endpoints.
  * Implemented an initial RPC method that echoes back the received payload.

* **Configuration**
  * Updated configuration to recognize and allow the new `rpc` endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->