### PR TITLE
docs: add RPC reference documentation

### DIFF
--- a/reference/rpc/BOARD.md
+++ b/reference/rpc/BOARD.md
@@ -20,11 +20,11 @@ Internally the function transparently chooses one of two data sources:
 
 | field  | type   | required | description                       |
 |--------|--------|----------|-----------------------------------|
-| symbol | string | Yes      | Four-digit stock code (e.g. "7203") |
+| symbol | string | Yes      | Four-digit stock code (e.g. "0000") |
 
 ```jsonc
 {
-  "symbol": "7203"
+  "symbol": "0000"
 }
 ```
 
@@ -48,7 +48,7 @@ Internally the function transparently chooses one of two data sources:
 {
   "is_ws_data": true,
   "board": {
-    "Symbol": "7203",
+    "Symbol": "0000",
     "CurrentPrice": 2030.5,
     "Bids": [ { "Price": 2030.0, "Qty": 1200 } ],
     "Asks": [ { "Price": 2031.0, "Qty": 800 } ]
@@ -63,3 +63,130 @@ Internally the function transparently chooses one of two data sources:
   automatically triggers registration.
 * On the very first call the REST path may add a few hundred milliseconds of
   latency before WebSocket data becomes available.
+
+---
+
+## Full JSON structure of `kabue_mufje_types:board()`
+
+When the Erlang `board()` map is converted to JSON using `jsone:encode/1`,
+every atom key becomes a snake-case string with the **exact name of the atom**
+and enum atoms are rendered as their textual atom names.  The example below
+shows all keys with illustrative values so you can see the full layout.
+
+```jsonc
+{
+  "symbol": "0000",
+  "symbol_name": "example ticker",
+  "exchange": "tokyo",          // enum atom → string
+  "exchange_name": "Tokyo",
+
+  "current_price": 2030.5,
+  "current_price_time": "2025-04-30T13:23:45+09:00",
+  "current_price_change_status": "up",
+  "current_price_status": "trading",
+  "calc_price": 2030.5,
+
+  "previous_close": 2010.0,
+  "previous_close_time": "2025-04-26T15:00:00+09:00",
+  "change_previous_close": 20.5,
+  "change_previous_close_per": 1.02,
+
+  "opening_price": 2025.0,
+  "opening_price_time": "2025-04-30T09:00:00+09:00",
+  "high_price": 2044.0,
+  "high_price_time": "2025-04-30T10:42:13+09:00",
+  "low_price": 2018.5,
+  "low_price_time": "2025-04-30T09:10:07+09:00",
+
+  "trading_volume": 18543200,
+  "trading_volume_time": "2025-04-30T13:23:00+09:00",
+  "vwap": 2028.4,
+  "trading_value": 37596288000,
+
+  // best quote (kabu’s Bid/Ask naming is swapped)
+  "bid_qty": 800,
+  "bid_price": 2031.0,
+  "bid_time": "13:23:45",
+  "bid_sign": "normal",
+  "market_order_sell_qty": 300,
+
+  // sell depth levels 1-10
+  "sell1_time": "13:23:45",
+  "sell1_sign": "normal",
+  "sell1_price": 2031.0,
+  "sell1_qty": 800,
+  "sell2_price": 2031.5,
+  "sell2_qty": 1200,
+  "sell3_price": 2032.0,
+  "sell3_qty": 1400,
+  "sell4_price": 2032.5,
+  "sell4_qty": 2000,
+  "sell5_price": 2033.0,
+  "sell5_qty": 1400,
+  "sell6_price": 2033.5,
+  "sell6_qty": 800,
+  "sell7_price": 2034.0,
+  "sell7_qty": 600,
+  "sell8_price": 2034.5,
+  "sell8_qty": 300,
+  "sell9_price": 2035.0,
+  "sell9_qty": 200,
+  "sell10_price": 2035.5,
+  "sell10_qty": 100,
+
+  // buy depth levels 1-10 (Ask side)
+  "ask_qty": 1200,
+  "ask_price": 2030.5,
+  "ask_time": "13:23:45",
+  "ask_sign": "normal",
+  "market_order_buy_qty": 500,
+
+  "buy1_time": "13:23:45",
+  "buy1_sign": "normal",
+  "buy1_price": 2030.5,
+  "buy1_qty": 1200,
+  "buy2_price": 2030.0,
+  "buy2_qty": 1400,
+  "buy3_price": 2029.5,
+  "buy3_qty": 2000,
+  "buy4_price": 2029.0,
+  "buy4_qty": 2400,
+  "buy5_price": 2028.5,
+  "buy5_qty": 2600,
+  "buy6_price": 2028.0,
+  "buy6_qty": 1800,
+  "buy7_price": 2027.5,
+  "buy7_qty": 1200,
+  "buy8_price": 2027.0,
+  "buy8_qty": 900,
+  "buy9_price": 2026.5,
+  "buy9_qty": 700,
+  "buy10_price": 2026.0,
+  "buy10_qty": 500,
+
+  // imbalance
+  "oversell_qty": 0,
+  "underbuy_qty": 200,
+
+  // stock specific
+  "total_market_value": 32500000000000,
+
+  // derivatives specific (fields are null for stocks)
+  "settlement_price": null,
+  "iv": null,
+  "gamma": null,
+  "theta": null,
+  "vega": null,
+  "delta": null
+}
+```
+
+### Encoding characteristics
+
+1. **Enums as strings** – `exchange`, `bid_sign`, etc. originate as atoms
+   that come from `kabue_mufje_enum:*()` look-ups.  They appear in JSON as
+   those atom names.
+2. **Numbers are numbers** – quantities and prices are JSON numbers.  kabu
+   sometimes returns decimals (`0.5`).
+3. **Nullable fields** – Keys not applicable to the instrument type are
+   encoded as `null`.

--- a/reference/rpc/BOARD.md
+++ b/reference/rpc/BOARD.md
@@ -1,21 +1,26 @@
-# `board` – Get board (order-book) information
+# `board` – Retrieve order-book information
 
 ```
 POST /kabue/rpc/board
 ```
 
-指定した銘柄（**現物株式**のみ）について、最新の板情報（気配・出来高等）を取得します。
+Returns the latest **order-book (board)** data for a single cash-equity symbol.
 
-内部実装では以下 2 つのデータソースを自動的に切り替えています。
+Internally the function transparently chooses one of two data sources:
 
-1. **WebSocket キャッシュ** – `kabue_mufje_ws_apic` で既に購読済みの銘柄であれば、メモリにキャッシュされた値を即座に返します（`is_ws_data = true`）。
-2. **REST API** – 未購読の場合は `kabuステーション REST /board` エンドポイントにアクセスし、同時に WebSocket の購読登録を行います（`is_ws_data = false`）。
+1. **WebSocket cache** – If the symbol is already subscribed through
+   `kabue_mufje_ws_apic`, the in-memory snapshot is returned immediately
+   (`is_ws_data = true`).
+2. **REST fallback** – Otherwise the function:
+   * Requests `/board` from the kabu Station REST API.
+   * Registers the symbol for WebSocket streaming so that subsequent calls are
+     served from cache (`is_ws_data = false` for the first call only).
 
 ## Request body
 
-| field  | type   | required | description |
-|--------|--------|----------|-------------|
-| symbol | string | Yes      | 銘柄コード（4 桁） |
+| field  | type   | required | description                       |
+|--------|--------|----------|-----------------------------------|
+| symbol | string | Yes      | Four-digit stock code (e.g. "7203") |
 
 ```jsonc
 {
@@ -27,16 +32,17 @@ POST /kabue/rpc/board
 
 ```jsonc
 {
-  "is_ws_data": true,    // or false – データ取得元
-  "board": { /* kabu REST /board 互換オブジェクト */ },
-  "time": 1714452123456   // UNIX epoch (ms)
+  "is_ws_data": true,          // or false – which data source was used
+  "board": { /* same shape as kabu REST /board */ },
+  "time": 1714452123456        // UNIX epoch (milliseconds)
 }
 ```
 
-* `board` の構造は kabu ステーション REST API の `/board` 応答と同一です。
-* `time` は取得時刻をミリ秒精度のエポックで返します。
+* The structure of `board` is identical to the kabu Station REST API
+  `/board` response.
+* `time` is the timestamp of retrieval in milliseconds since the epoch.
 
-### 例
+### Example
 
 ```jsonc
 {
@@ -44,8 +50,8 @@ POST /kabue/rpc/board
   "board": {
     "Symbol": "7203",
     "CurrentPrice": 2030.5,
-    "Bids": [ { "Price": 2030.0, "Qty": 1200 }, … ],
-    "Asks": [ { "Price": 2031.0, "Qty": 800 }, … ]
+    "Bids": [ { "Price": 2030.0, "Qty": 1200 } ],
+    "Asks": [ { "Price": 2031.0, "Qty": 800 } ]
   },
   "time": 1714452123456
 }
@@ -53,5 +59,7 @@ POST /kabue/rpc/board
 
 ## Notes
 
-* 呼び出し側が明示的に WebSocket 購読する処理を書く必要はありません。未購読の場合でも自動的に登録されます。
-* **初回呼び出し**で REST API を叩いた場合は、WebSocket データが届くまでに最大数百 ms 程度の遅延が発生することがあります。
+* Clients do **not** need to subscribe to WebSocket themselves—first access
+  automatically triggers registration.
+* On the very first call the REST path may add a few hundred milliseconds of
+  latency before WebSocket data becomes available.

--- a/reference/rpc/BOARD.md
+++ b/reference/rpc/BOARD.md
@@ -1,0 +1,57 @@
+# `board` – Get board (order-book) information
+
+```
+POST /kabue/rpc/board
+```
+
+指定した銘柄（**現物株式**のみ）について、最新の板情報（気配・出来高等）を取得します。
+
+内部実装では以下 2 つのデータソースを自動的に切り替えています。
+
+1. **WebSocket キャッシュ** – `kabue_mufje_ws_apic` で既に購読済みの銘柄であれば、メモリにキャッシュされた値を即座に返します（`is_ws_data = true`）。
+2. **REST API** – 未購読の場合は `kabuステーション REST /board` エンドポイントにアクセスし、同時に WebSocket の購読登録を行います（`is_ws_data = false`）。
+
+## Request body
+
+| field  | type   | required | description |
+|--------|--------|----------|-------------|
+| symbol | string | Yes      | 銘柄コード（4 桁） |
+
+```jsonc
+{
+  "symbol": "7203"
+}
+```
+
+## Response body
+
+```jsonc
+{
+  "is_ws_data": true,    // or false – データ取得元
+  "board": { /* kabu REST /board 互換オブジェクト */ },
+  "time": 1714452123456   // UNIX epoch (ms)
+}
+```
+
+* `board` の構造は kabu ステーション REST API の `/board` 応答と同一です。
+* `time` は取得時刻をミリ秒精度のエポックで返します。
+
+### 例
+
+```jsonc
+{
+  "is_ws_data": true,
+  "board": {
+    "Symbol": "7203",
+    "CurrentPrice": 2030.5,
+    "Bids": [ { "Price": 2030.0, "Qty": 1200 }, … ],
+    "Asks": [ { "Price": 2031.0, "Qty": 800 }, … ]
+  },
+  "time": 1714452123456
+}
+```
+
+## Notes
+
+* 呼び出し側が明示的に WebSocket 購読する処理を書く必要はありません。未購読の場合でも自動的に登録されます。
+* **初回呼び出し**で REST API を叩いた場合は、WebSocket データが届くまでに最大数百 ms 程度の遅延が発生することがあります。

--- a/reference/rpc/ECHO.md
+++ b/reference/rpc/ECHO.md
@@ -4,11 +4,17 @@
 POST /kabue/rpc/echo
 ```
 
-最も単純な RPC です。受け取った JSON をそのまま返します。
+The simplest RPC: it returns whatever JSON object you send.  This is useful to
+verify that
+
+* The HTTP route (`/kabue/rpc/echo`) is reachable.
+* Authorization (if any reverse-proxy is in front) is working.
+* The Cowboy → JSON decode/encode → `kabue_rpc` function chain behaves as
+  expected.
 
 ## Request body
 
-Any JSON object. 例：
+Any JSON object, for example:
 
 ```jsonc
 {
@@ -19,7 +25,7 @@ Any JSON object. 例：
 
 ## Response body
 
-リクエストで送った JSON がそのまま返ります。
+Exactly the same JSON object is returned:
 
 ```jsonc
 {
@@ -28,9 +34,4 @@ Any JSON object. 例：
 }
 ```
 
-## 用途
-
-* API エンドポイントまで通信／認証経路が確立しているかを確認する。
-* `kabue_rpc` のハンドラチェーン（Cowboy, JSON デコード／エンコード）が正しく動作しているかをテストする。
-
-> **備考**: サーバコード側では `kabue_rpc:echo/1` が単に引数を返しているだけです。
+> Implementation note: `kabue_rpc:echo/1` simply returns its argument.

--- a/reference/rpc/ECHO.md
+++ b/reference/rpc/ECHO.md
@@ -1,0 +1,36 @@
+# `echo` – Connectivity test
+
+```
+POST /kabue/rpc/echo
+```
+
+最も単純な RPC です。受け取った JSON をそのまま返します。
+
+## Request body
+
+Any JSON object. 例：
+
+```jsonc
+{
+  "hello": "world",
+  "value": 123
+}
+```
+
+## Response body
+
+リクエストで送った JSON がそのまま返ります。
+
+```jsonc
+{
+  "hello": "world",
+  "value": 123
+}
+```
+
+## 用途
+
+* API エンドポイントまで通信／認証経路が確立しているかを確認する。
+* `kabue_rpc` のハンドラチェーン（Cowboy, JSON デコード／エンコード）が正しく動作しているかをテストする。
+
+> **備考**: サーバコード側では `kabue_rpc:echo/1` が単に引数を返しているだけです。

--- a/reference/rpc/ORDER_LIST.md
+++ b/reference/rpc/ORDER_LIST.md
@@ -1,0 +1,35 @@
+# `order_list` – Show open / filled orders
+
+```
+POST /kabue/rpc/order_list
+```
+
+現在発注中の注文を一覧取得し、**注文数量と約定数量の差**に基づいて簡易的に 3 つのカテゴリにグループ化します。
+
+* `all` – 完全約定した注文（残数量 = 0）
+* `partial` – 一部約定（残数量 > 0 かつ 約定数量 > 0）
+* `none` – まったく約定していない注文（約定数量 = 0）
+
+## Request body
+
+空オブジェクトのみを受け付けます。
+
+```json
+{}
+```
+
+## Response body
+
+```jsonc
+{
+  "order_list": [ /* kabu REST /orders 互換配列 */ ],
+  "id_buckets": {
+    "all":     ["202504240001"],
+    "partial": ["202504240002"],
+    "none":    ["202504240003", "202504240004"]
+  }
+}
+```
+
+* `order_list` は kabu ステーション REST API `/orders` のレスポンス構造をそのまま返します。
+* `id_buckets` は追加で計算した **注文 ID のみ** の配列です。UI での色分けやフィルタリングに利用できます。

--- a/reference/rpc/ORDER_LIST.md
+++ b/reference/rpc/ORDER_LIST.md
@@ -1,18 +1,21 @@
-# `order_list` – Show open / filled orders
+# `order_list` – Categorise current orders
 
 ```
 POST /kabue/rpc/order_list
 ```
 
-現在発注中の注文を一覧取得し、**注文数量と約定数量の差**に基づいて簡易的に 3 つのカテゴリにグループ化します。
+Returns the current order list together with three **ID buckets** that make it
+easy to display status in a UI.
 
-* `all` – 完全約定した注文（残数量 = 0）
-* `partial` – 一部約定（残数量 > 0 かつ 約定数量 > 0）
-* `none` – まったく約定していない注文（約定数量 = 0）
+| bucket   | criteria                                               |
+|----------|--------------------------------------------------------|
+| `all`    | Completely filled (`order_qty - cum_qty ≈ 0`)          |
+| `partial`| Partially filled (cum_qty > 0 but not full)            |
+| `none`   | No fill at all (cum_qty ≈ 0)                           |
 
 ## Request body
 
-空オブジェクトのみを受け付けます。
+Send an empty object – no parameters are required:
 
 ```json
 {}
@@ -22,7 +25,7 @@ POST /kabue/rpc/order_list
 
 ```jsonc
 {
-  "order_list": [ /* kabu REST /orders 互換配列 */ ],
+  "order_list": [ /* full REST /orders payload */ ],
   "id_buckets": {
     "all":     ["202504240001"],
     "partial": ["202504240002"],
@@ -31,5 +34,6 @@ POST /kabue/rpc/order_list
 }
 ```
 
-* `order_list` は kabu ステーション REST API `/orders` のレスポンス構造をそのまま返します。
-* `id_buckets` は追加で計算した **注文 ID のみ** の配列です。UI での色分けやフィルタリングに利用できます。
+* `order_list` is exactly what kabu Station REST API `/orders` returns.
+* `id_buckets` contains only the order IDs – handy for coloring rows or quick
+  filtering.

--- a/reference/rpc/OVERVIEW.md
+++ b/reference/rpc/OVERVIEW.md
@@ -35,25 +35,13 @@ individual markdown files placed next to this one.
 
 ---
 
-### Common error response
+### Error handling
 
-All RPCs share the same error model used internally by the kabue code base:
+* Each RPC function is free to design its own **success / error payload**.
+* If an un-handled Erlang exception occurs inside the function, Cowboy will
+  automatically respond with **HTTP 500 Internal Server Error** and an empty
+  body.
 
-````jsonc
-{
-  "success": false,
-  "payload": { /* description or stack trace */ }
-}
-````
-
-However, many functions return `{left, Payload}` tuples internally and the
-handler currently **does not intercept** those.  Therefore the HTTP layer
-will still respond with *200* and the JSON body will directly be the Erlang
-tuple that the function returned, for example:
-
-```json
-["left", {"reason": "token_expired"}]
-```
-
-Treat any response that is not documented in the specification below as an
-internal error.
+In other words *application-level* errors are communicated by the individual
+function (and are documented in its dedicated markdown file), whereas
+unexpected crashes surface as HTTP 500.

--- a/reference/rpc/OVERVIEW.md
+++ b/reference/rpc/OVERVIEW.md
@@ -1,0 +1,59 @@
+# Kabue RPC API – Overview
+
+Kabue exposes a small **RPC style** HTTP endpoint that allows the front-end
+or automation scripts to invoke server side functions that are **not** part of
+the official kabu ステーション REST / WebSocket API.
+
+*   Base URL (default build): `http://<host>:<port>/kabue/rpc/{id}`
+*   HTTP Method: **POST** *(only)*
+*   Content-Type: any (the server always tries to decode the body as JSON)
+*   Request Body: JSON object that is passed as Erlang map argument to the
+    corresponding function `kabue_rpc:{id}/1` on the server.
+
+If the *id* segment in the path matches an exported function of
+`kabue_rpc.erl` (arity = 1) the request is accepted, the function is executed
+and its return value is encoded back to JSON and sent in the response body
+(HTTP 200).
+
+When the *id* does not exist or  the method is not `POST`, the server responds
+with **404 Not Found**.
+
+---
+
+## Available RPC methods
+
+| id (function) | Summary |
+|---------------|---------|
+| `echo` | Echos back the request payload. Mainly for connectivity test |
+| `board` | Returns board (order-book) information for one symbol |
+| `quick_take` | *Demo/utility*: buys 1 share of 1459 and immediately places a take-profit order |
+| `order_list` | Lists current orders and groups their IDs by filled state |
+| `panic_exit` | Cancels all open orders **and** immediately closes all positions |
+
+Detailed request / response specification for every RPC is available in the
+individual markdown files placed next to this one.
+
+---
+
+### Common error response
+
+All RPCs share the same error model used internally by the kabue code base:
+
+````jsonc
+{
+  "success": false,
+  "payload": { /* description or stack trace */ }
+}
+````
+
+However, many functions return `{left, Payload}` tuples internally and the
+handler currently **does not intercept** those.  Therefore the HTTP layer
+will still respond with *200* and the JSON body will directly be the Erlang
+tuple that the function returned, for example:
+
+```json
+["left", {"reason": "token_expired"}]
+```
+
+Treat any response that is not documented in the specification below as an
+internal error.

--- a/reference/rpc/OVERVIEW.md
+++ b/reference/rpc/OVERVIEW.md
@@ -1,8 +1,8 @@
 # Kabue RPC API – Overview
 
-Kabue exposes a small **RPC style** HTTP endpoint that allows the front-end
-or automation scripts to invoke server side functions that are **not** part of
-the official kabu ステーション REST / WebSocket API.
+Kabue exposes a small **RPC-style** HTTP endpoint that allows front-end code
+or automation scripts to invoke server-side functions that are **not** part of
+the official **kabu Station** REST / WebSocket API.
 
 *   Base URL (default build): `http://<host>:<port>/kabue/rpc/{id}`
 *   HTTP Method: **POST** *(only)*

--- a/reference/rpc/PANIC_EXIT.md
+++ b/reference/rpc/PANIC_EXIT.md
@@ -1,23 +1,25 @@
-# `panic_exit` – Emergency flat position
+# `panic_exit` – Emergency exit helper
 
 ```
 POST /kabue/rpc/panic_exit
 ```
 
-**全ての未約定注文を取消し、残っている建玉を即座に反対売買で決済する** 緊急用 RPC です。
+Cancels every open order **and** immediately closes all remaining positions
+at market price.  Use this RPC when you need to flatten exposure as fast as
+possible.
 
-## 処理内容
+## Processing steps
 
-1. REST API `/orders` で取得した注文のうち、`state != finished`（受付 / 活動中）を **すべて取消** します。
-2. REST API `/positions` で取得した **残数量 > 0** の建玉に対し、
-   * 現物 – `market` 成行で反対売買 (`cash_margin = spot`)
-   * 信用 – `market` 成行で返済 (`cash_margin = margin_repay`)
-   を一括で発注します。
-3. キャンセル・返済それぞれの結果をまとめて返却します。
+1. Fetch the order list via REST `/orders`.
+2. For any order whose `state` is *not* `finished`, issue `/cancelorder`.
+3. Fetch positions via REST `/positions`.
+4. For each position with `leaves_qty > 0` submit a market order on the
+   opposite side (cash-margin logic handled by the function).
+5. Aggregate the results and return a summary JSON.
 
 ## Request body
 
-空オブジェクトのみを受け付けます。
+Send an empty object:
 
 ```json
 {}
@@ -28,23 +30,26 @@ POST /kabue/rpc/panic_exit
 ```jsonc
 {
   "cancel_list": ["202504240001", "202504240002"],
-  "exit_list": [ /* 発注に使用した注文オブジェクト */ ],
+  "exit_list": [ /* order objects used for close-out */ ],
   "cancel_result": [
-    { "success": true,  "payload": { /* REST /cancelorder 応答 */ } },
-    { "success": false, "payload": { "Code": 4001020, "Message": "失効" } }
+    { "success": true,  "payload": { /* REST /cancelorder response */ } },
+    { "success": false, "payload": { "Code": 4001020, "Message": "Expired" } }
   ],
   "exit_result": [
-    { "success": true,  "payload": { /* REST /sendorder 応答 */ } }
+    { "success": true,  "payload": { /* REST /sendorder response */ } }
   ]
 }
 ```
 
-* `cancel_result` / `exit_result` は個別の REST API 呼び出しを **left / right** いずれかの `either` タプルから組み立てたものです。
-  * `success = true` – タプルが `{right, Payload}` だった場合
-  * `success = false` – タプルが `{left,  Payload}` だった場合
+* Each element in `cancel_result` / `exit_result` is created from an `either`
+  tuple returned by the underlying library:
+  * `success = true`   → `{right, Payload}`
+  * `success = false`  → `{left,  Payload}`
 
-## 注意事項
+## Caveats
 
-* 建玉が **複数の商品区分（スポット現物、信用 etc.）** に跨っていても単一呼び出しでクローズします。
-* 取消不能（すでに全約定 / 失効済み）の注文は `cancel_result` に `success = false` で格納されます。エラーとしては扱いません。
-* 建玉が無い場合は `exit_list` と `exit_result` が空配列になります。
+* Works across **both** cash-equity and margin positions.
+* Orders that cannot be canceled (already fully filled or expired) appear in
+  `cancel_result` with `success = false`; this is expected and does not stop
+  processing.
+* If there are no positions the arrays `exit_list` and `exit_result` are empty.

--- a/reference/rpc/PANIC_EXIT.md
+++ b/reference/rpc/PANIC_EXIT.md
@@ -1,0 +1,50 @@
+# `panic_exit` – Emergency flat position
+
+```
+POST /kabue/rpc/panic_exit
+```
+
+**全ての未約定注文を取消し、残っている建玉を即座に反対売買で決済する** 緊急用 RPC です。
+
+## 処理内容
+
+1. REST API `/orders` で取得した注文のうち、`state != finished`（受付 / 活動中）を **すべて取消** します。
+2. REST API `/positions` で取得した **残数量 > 0** の建玉に対し、
+   * 現物 – `market` 成行で反対売買 (`cash_margin = spot`)
+   * 信用 – `market` 成行で返済 (`cash_margin = margin_repay`)
+   を一括で発注します。
+3. キャンセル・返済それぞれの結果をまとめて返却します。
+
+## Request body
+
+空オブジェクトのみを受け付けます。
+
+```json
+{}
+```
+
+## Response body
+
+```jsonc
+{
+  "cancel_list": ["202504240001", "202504240002"],
+  "exit_list": [ /* 発注に使用した注文オブジェクト */ ],
+  "cancel_result": [
+    { "success": true,  "payload": { /* REST /cancelorder 応答 */ } },
+    { "success": false, "payload": { "Code": 4001020, "Message": "失効" } }
+  ],
+  "exit_result": [
+    { "success": true,  "payload": { /* REST /sendorder 応答 */ } }
+  ]
+}
+```
+
+* `cancel_result` / `exit_result` は個別の REST API 呼び出しを **left / right** いずれかの `either` タプルから組み立てたものです。
+  * `success = true` – タプルが `{right, Payload}` だった場合
+  * `success = false` – タプルが `{left,  Payload}` だった場合
+
+## 注意事項
+
+* 建玉が **複数の商品区分（スポット現物、信用 etc.）** に跨っていても単一呼び出しでクローズします。
+* 取消不能（すでに全約定 / 失効済み）の注文は `cancel_result` に `success = false` で格納されます。エラーとしては扱いません。
+* 建玉が無い場合は `exit_list` と `exit_result` が空配列になります。

--- a/reference/rpc/QUICK_TAKE.md
+++ b/reference/rpc/QUICK_TAKE.md
@@ -1,0 +1,47 @@
+# `quick_take` – One-shot day-trade helper (demo)
+
+```
+POST /kabue/rpc/quick_take
+```
+
+> **⚠️ 警告**: 実際に **成行**で買い注文を発注し、その後すぐに利確注文（指値）を置く *デモユーティリティ* です。運用環境での使用は推奨しません。コード上では銘柄 **1459** がハードコーディングされています。
+
+## 機能概要
+
+1. `1459` を 1 株 **成行買い**します。
+2. 約定価格 + 1 円で **指値売り**（建玉返済）を即座に発注します。
+3. 注文 ID などを返却します。
+
+## Request body
+
+| field  | type | required | description |
+|--------|------|----------|-------------|
+| symbol | string | Yes | **必ず "1459"** を指定してください。それ以外の値を送ると 500 になります（関数内でパターンマッチ）。 |
+
+```jsonc
+{
+  "symbol": "1459"
+}
+```
+
+## Response body
+
+| field | type   | description |
+|-------|--------|-------------|
+| order_id | string | 買い注文の ID |
+| close_order_id | string | 売り（返済）注文の ID |
+| close_order_price | number | 指値価格（約定最⾼値 + 1 円） |
+
+```jsonc
+{
+  "order_id": "202504240001",
+  "close_order_id": "202504240002",
+  "close_order_price": 2032.5
+}
+```
+
+## 注意事項
+
+* 取引区分は **信用・一般デイトレ（制度／プレ空ではない）** 固定です。
+* 売り返済注文は `nonlimit_open_afternoon`（寄成 OPGO 相当？）がハードコードされています。市場状況により約定しない可能性があります。
+* 銘柄や数量・利幅はコードを改修しない限り変更できません。あくまで PoC（Proof-of-Concept）用です。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new RPC endpoints for enhanced trading operations:
    * Retrieve the latest board (order-book) information for a specified stock symbol.
    * Fetch a categorized list of current orders by fill status.
    * Execute an emergency operation to cancel all orders and close all positions.
    * Perform a demo one-shot day trade for a specific stock symbol.
    * Test connectivity using an echo endpoint.
* **Documentation**
  * Added detailed documentation for all new RPC endpoints and provided an overview of the Kabue RPC API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->